### PR TITLE
Revised ex3 and ex4 tests

### DIFF
--- a/hashtables/ex3/ex3.py
+++ b/hashtables/ex3/ex3.py
@@ -10,8 +10,8 @@ def intersection(arrays):
 if __name__ == "__main__":
     arrays = []
 
-    arrays.append(list(range(1000000, 2000000)) + [1, 2, 3])
-    arrays.append(list(range(2000000, 3000000)) + [1, 2, 3])
+    arrays.append(list(range(1000000, 2000000)) + [1, 2, 3, 4])
+    arrays.append(list(range(2000000, 3000000)) + [1, 2, 3, 4])
     arrays.append(list(range(3000000, 4000000)) + [1, 2, 3])
 
     print(intersection(arrays))

--- a/hashtables/ex3/ex3_tests.py
+++ b/hashtables/ex3/ex3_tests.py
@@ -8,7 +8,7 @@ class TestEx2(unittest.TestCase):
     def test_small(self):
         result = intersection([
             [1,2,3],
-            [1,4,5],
+            [1,2,5],
             [1,6,7]
         ])
         self.assertTrue(result == [1])

--- a/hashtables/ex3/ex3_tests.py
+++ b/hashtables/ex3/ex3_tests.py
@@ -35,8 +35,8 @@ class TestEx2(unittest.TestCase):
 
     def test_large(self):
         arrays = [
-            list(range(1000000, 2000000)) + [1,2,3],
-            list(range(2000000, 3000000)) + [1,2,3],
+            list(range(1000000, 2000000)) + [1,2,3,4],
+            list(range(2000000, 3000000)) + [1,2,3,4],
             list(range(3000000, 4000000)) + [1,2,3],
             list(range(4000000, 5000000)) + [1,2,3],
             list(range(5000000, 6000000)) + [1,2,3],

--- a/hashtables/ex4/ex4.py
+++ b/hashtables/ex4/ex4.py
@@ -8,4 +8,4 @@ def has_negatives(a):
 
 
 if __name__ == "__main__":
-    print(has_negatives([-1, -2, 1, 2, 3, 4, -4]))
+    print(has_negatives([-1, -2, 1, 2, 3, 3, 4, -4]))

--- a/hashtables/ex4/ex4_tests.py
+++ b/hashtables/ex4/ex4_tests.py
@@ -12,7 +12,7 @@ class TestEx4(unittest.TestCase):
         result = has_negatives([1,2,3,-4])
         self.assertTrue(result == [])
 
-        result = has_negatives([-1,-2,1,2,3,4,-4])
+        result = has_negatives([-1,-2,1,2,3,3,4,-4])
         result.sort()
         self.assertTrue(result == [1,2,4])
 


### PR DESCRIPTION
The ex3 tests are currently structured such that the only entries appearing in more than one list are part of the intersection of all lists. Some student solutions were checking only for any number that appeared multiple times, not for it to appear in all lists. I added duplicate entries across some but not all of the lists to catch solutions that return false positives in this way. 

For ex4, some solutions checked only to see if a number's absolute value appeared twice, not necessarily for both a positive integer and its negative, but the tests would still pass. I added duplicate positive integers to differentiate between these correct and incorrect solutions.