### PR TITLE
Update README.md

### DIFF
--- a/hashtables/ex1/README.md
+++ b/hashtables/ex1/README.md
@@ -10,7 +10,7 @@ function will return a tuple of integers that has the following form:
 ```
 
 where each element represents the item weights of the two packages.
-_**The higher valued index should be placed in the `zeroth` index and
+_**The higher index should be placed in the `zeroth` index and
 the smaller index should be placed in the `first` index.**_ If such a
 pair doesn’t exist for the given inputs, your function should return
 `None`.


### PR DESCRIPTION
Submitting PR to improve the Readme. The line which says:
"The higher valued index should be placed in the `zeroth` index and the smaller index should be placed in the `first` index". 

Recommend dropping the word 'valued' to make this clearer as it reads as if the higher value of the index instead of the higher index.
Multiple students commented on this as confusing.
Also since the index is the value in dictionary, it further complicates the intent so the proposed tweak would make this clearer.